### PR TITLE
Refactor version keys in opend_version.json and update related scripts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,14 +25,14 @@ jobs:
         with:
           script: |
             const config = require('./opend_version.json');
-            return config.beta_version;
+            return config.betaVersion;
           result-encoding: string
       - uses: actions/github-script@v7
         id: stable_version
         with:
           script: |
             const config = require('./opend_version.json');
-            return config.stable_version;
+            return config.stableVersion;
           result-encoding: string
       - id: set-matrix
         uses: actions/github-script@v7

--- a/opend_version.json
+++ b/opend_version.json
@@ -1,4 +1,4 @@
 {
-  "beta_version": null,
-  "stable_version": "9.3.5308"
+  "betaVersion": null,
+  "stableVersion": "9.3.5308"
 }

--- a/script/check_version.js
+++ b/script/check_version.js
@@ -46,7 +46,8 @@ async function main () {
   console.log(data)
 
   const outputFilePath = path.join(__dirname, '..', 'opend_version.json')
-  fs.writeFileSync(outputFilePath, JSON.stringify(data, null, 2), 'utf8')
+  const jsonString = JSON.stringify(data, null, 2) + '\n'
+  fs.writeFileSync(outputFilePath, jsonString, 'utf8')
   console.log(`Version data written to ${outputFilePath}`)
 }
 


### PR DESCRIPTION
- Changed keys in opend_version.json from camel case to snake case for consistency.
- Updated references in the publish workflow and check_version.js script to match the new key format.
- Ensured JSON output in check_version.js ends with a newline for better formatting.
