### PR TITLE
ci: set GH_REPO so auto-merge gh CLI works without checkout

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Check PR status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           echo "Checking PR #$PR_NUMBER for auto-merge eligibility..."


### PR DESCRIPTION
## Summary
- Adds `GH_REPO: ${{ github.repository }}` to the `Check PR status` step in `.github/workflows/auto-merge.yml`.
- The Auto Merge PR workflow runs `gh` commands without `actions/checkout`, so `gh` cannot infer the target repo from a local git remote and fails with `fatal: not a git repository`.
- Setting `GH_REPO` gives `gh` the repo context it needs without paying for a checkout.

Reproduces the failure seen in [run 24866453251](https://github.com/manhinhang/futu-opend-docker/actions/runs/24866453251/job/72965834334?pr=59).

## Test plan
- [x] Verified locally with act CLI against a synthesized PR event payload — the `Check PR status` step now reaches the `gh pr view` / `gh pr checks` calls successfully and reports PR status.
- [ ] After merge, the next bot-authored "Update Futu OpenD version" PR (created by the daily `0 0 * * *` cron in `check-ver-upadte.yml`) should run Auto Merge PR cleanly.