### PR TITLE
feat: persist FutuOpenD login session via named volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,12 @@ ENV FUTU_OPEND_PORT=11111
 ENV FUTU_OPEND_TELNET_PORT=22222
 
 # Create non-root user and necessary directories
+# /home/futu/.com.futunn.FutuOpenD is FutuOpenD's runtime state dir; pre-creating it
+# (owned by futu) lets a named volume mounted there inherit the right ownership on
+# first attach. Without this, Docker creates the mount point as root and OpenD EACCES.
 RUN groupadd -r futu && useradd -r -g futu -m -d /home/futu futu && \
-    mkdir -p /.futu /bin && chown -R futu:futu /.futu /bin /home/futu
+    mkdir -p /.futu /bin /home/futu/.com.futunn.FutuOpenD && \
+    chown -R futu:futu /.futu /bin /home/futu
 
 COPY script/start.sh /bin/start.sh
 RUN chmod +x /bin/start.sh && chown futu:futu /bin/start.sh
@@ -86,8 +90,12 @@ ENV FUTU_OPEND_PORT=11111
 ENV FUTU_OPEND_TELNET_PORT=22222
 
 # Create non-root user and necessary directories
+# /home/futu/.com.futunn.FutuOpenD is FutuOpenD's runtime state dir; pre-creating it
+# (owned by futu) lets a named volume mounted there inherit the right ownership on
+# first attach. Without this, Docker creates the mount point as root and OpenD EACCES.
 RUN groupadd -r futu && useradd -r -g futu -m -d /home/futu futu && \
-    mkdir -p /.futu /bin && chown -R futu:futu /.futu /bin /home/futu
+    mkdir -p /.futu /bin /home/futu/.com.futunn.FutuOpenD && \
+    chown -R futu:futu /.futu /bin /home/futu
 
 COPY script/start.sh /bin/start.sh
 RUN chmod +x /bin/start.sh && chown futu:futu /bin/start.sh

--- a/README.md
+++ b/README.md
@@ -36,11 +36,16 @@ docker run -it --name futu-opend-docker \
 -e FUTU_ACCOUNT_ID=<your_account_id> \
 -e FUTU_ACCOUNT_PWD=<your_password> \
 -v $(pwd)/futu.pem:/.futu/futu.pem \
+-v futu-opend-data:/home/futu/.com.futunn.FutuOpenD \
 -p 11111:11111 \
 -p 22222:22222 \
 ghcr.io/manhinhang/futu-opend-docker
 ```
 
+> The `futu-opend-data` named volume keeps FutuOpenD's login session across
+> container recreates so SMS verification isn't required on every restart.
+> See [Login session persistence](#login-session-persistence) for details.
+>
 > **Port mappings**:
 >
 > - `11111`: API port for FutuOpenD protocol
@@ -166,6 +171,35 @@ Edit `.env` (auto-loaded by `docker compose`):
 docker compose up -d
 ```
 
+### Login session persistence
+
+The compose stack mounts a named volume `futu-opend-data` at
+`/home/futu/.com.futunn.FutuOpenD` inside the container. FutuOpenD writes
+its runtime state there — device-whitelist token, login cache, captcha
+PNG, and other session metadata. With this volume in place, SMS
+verification is **only required when the volume is empty** (first ever
+run, account switch, or explicit wipe).
+
+**Caveat — Futu-side whitelist lifetime**: Futu's server-side device
+whitelist has a short shelf life (hours to days). When Futu invalidates
+the whitelist, the next login will prompt for SMS again regardless of
+what's in the volume. The volume eliminates _Docker-recreate-induced_
+fresh-device churn; it does not extend Futu's own whitelist policy.
+
+**Wipe the volume** to force a fresh login:
+
+```bash
+docker compose down -v
+# or, while the stack is down:
+docker volume rm futu-opend-docker_futu-opend-data
+```
+
+Wipe when:
+
+- Switching to a different `FUTU_ACCOUNT_ID`.
+- After upgrading FutuOpenD across major versions.
+- Diagnosing login loops that don't respond to credential rotation.
+
 ### Healthcheck
 
 The container includes a healthcheck that monitors the FutuOpenD process:
@@ -243,6 +277,7 @@ If the container fails to start:
 1. **RSA key**: Ensure `futu.pem` exists and is properly mounted at `/.futu/futu.pem`
 2. **Environment variables**: Verify `FUTU_ACCOUNT_ID` and either `FUTU_ACCOUNT_PWD` or `FUTU_ACCOUNT_PWD_MD5` are set
 3. **Verification required**: First run may require verification codes
+4. **Stale session state**: if you've changed accounts or upgraded OpenD across major versions, wipe the data volume — see [Login session persistence](#login-session-persistence).
 
 ### Verification codes
 

--- a/README.md
+++ b/README.md
@@ -173,12 +173,14 @@ docker compose up -d
 
 ### Login session persistence
 
-The compose stack mounts a named volume `futu-opend-data` at
-`/home/futu/.com.futunn.FutuOpenD` inside the container. FutuOpenD writes
-its runtime state there — device-whitelist token, login cache, captcha
-PNG, and other session metadata. With this volume in place, SMS
-verification is **only required when the volume is empty** (first ever
-run, account switch, or explicit wipe).
+Mounting the `futu-opend-data` named volume at
+`/home/futu/.com.futunn.FutuOpenD` lets FutuOpenD's runtime state —
+device-whitelist token, login cache, captcha PNG, and other session
+metadata — survive container recreate. The compose stack attaches it
+automatically; bare `docker run` users add
+`-v futu-opend-data:/home/futu/.com.futunn.FutuOpenD`. With the volume in
+place, SMS verification is **only required when the volume is empty**
+(first ever run, account switch, or explicit wipe).
 
 **Caveat — Futu-side whitelist lifetime**: Futu's server-side device
 whitelist has a short shelf life (hours to days). When Futu invalidates
@@ -186,13 +188,30 @@ the whitelist, the next login will prompt for SMS again regardless of
 what's in the volume. The volume eliminates _Docker-recreate-induced_
 fresh-device churn; it does not extend Futu's own whitelist policy.
 
-**Wipe the volume** to force a fresh login:
+**Image version requirement**: this volume needs an image built from a
+Dockerfile that pre-creates `/home/futu/.com.futunn.FutuOpenD` with
+`futu` ownership (introduced alongside this volume). Older published
+images leave the mount point owned by `root`, and FutuOpenD (running as
+`futu`) will EACCES on first write. Run `docker compose pull` (or
+`docker compose build`) when adopting this change.
+
+**Wipe the volume** to force a fresh login. The volume's actual name
+depends on how you launched the stack (compose namespaces it by project
+directory; `docker run` does not):
 
 ```bash
+# Compose users — wipes everything in one step:
 docker compose down -v
-# or, while the stack is down:
+
+# Compose users — manual, while the stack is down:
 docker volume rm futu-opend-docker_futu-opend-data
+
+# Bare `docker run` users:
+docker rm -f futu-opend-docker
+docker volume rm futu-opend-data
 ```
+
+Run `docker volume ls` if you're not sure which volume name applies.
 
 Wipe when:
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,9 +36,16 @@ services:
       FUTU_OPEND_WEBSOCKET_IP: ${FUTU_OPEND_WEBSOCKET_IP:-}
     volumes:
       - $LOCAL_RSA_FILE_PATH:/.futu/futu.pem
+      # FutuOpenD writes its runtime state (device-whitelist token, login
+      # cache, captcha PNG) here. Persisting it across recreates lets Futu
+      # skip SMS until the server-side whitelist window expires.
+      - futu-opend-data:/home/futu/.com.futunn.FutuOpenD
     healthcheck:
       test: ["CMD", "bash", "-c", "</dev/tcp/127.0.0.1/11111"]
       interval: 60s
       timeout: 10s
       retries: 5
       start_period: 120s
+
+volumes:
+  futu-opend-data:


### PR DESCRIPTION
## Summary

Mount a Docker named volume `futu-opend-data` at `/home/futu/.com.futunn.FutuOpenD` so FutuOpenD's session state — most importantly the device-whitelist token in `Device.dat` — survives container recreate. Today every `docker compose down/up` (or any container recreation) wipes that directory, so Futu sees a fresh device on each restart and prompts for SMS verification. With this volume in place, SMS is required only on the first run / explicit wipe / Futu-side whitelist expiry.

## Changes

- **Dockerfile** (`final-ubuntu-image` and `final-centos-image` stages): pre-create `/home/futu/.com.futunn.FutuOpenD` and let the existing recursive `chown -R futu:futu /home/futu` cover it. Without this, Docker creates the mount point as `root:root` on first volume attach and FutuOpenD (running as `futu`) gets EACCES.
- **docker-compose.yaml**: add `futu-opend-data:/home/futu/.com.futunn.FutuOpenD` to the volumes list and declare the named volume top-level.
- **README.md**: add the corresponding `-v` flag to the bare `docker run` example, add a new "Login session persistence" section explaining what the volume holds + how to wipe it (account switch, version upgrade, login loops) + the Futu-side whitelist-lifetime caveat (server-side window is hours-to-days regardless of volume), and a troubleshooting bullet.
- **No change** to `script/start.sh`, the e2e suite, or the build pipeline. `script/lib/docker.mjs` already runs `compose down -v --remove-orphans`, so the e2e regression contract ("each successful run consumes one Futu login session" — `docs/E2E.md:205`) is preserved.

## Files Changed

| File | Change |
|---|---|
| `Dockerfile` | Modified — pre-create mount point in both final stages |
| `docker-compose.yaml` | Modified — add named volume entry + top-level declaration |
| `README.md` | Modified — `docker run` flag, new persistence section, troubleshooting bullet |

## Testing

End-to-end verified locally:

1. **Clean baseline**: `docker compose down -v` removed prior volumes.
2. **First login**: `docker compose up -d --build` triggered `>>>需要手机验证码`; SMS code delivered via `nc localhost 22222`; login completed (`>>>WebSocket监听地址: 0.0.0.0: 33333`).
3. **Mount-point ownership**: `docker exec futu-opend stat -c '%U:%G' /home/futu/.com.futunn.FutuOpenD` → `futu:futu` ✓.
4. **Volume populated**: `Device.dat`, `LocalStore.dat`, `F3CNN/`, `Log/` all owned by `futu`.
5. **Persistence test**: `docker compose down && docker compose up -d` (no `-v`) — recreated container went `>>>正在登录` → `>>>登录成功` directly, **no** SMS prompt, no `req_phone_verify_code` line in logs. ✓

E2E suite (`npm run test:e2e`) is expected to still pass unchanged because its existing `compose down -v --remove-orphans` cleanup wipes the new named volume between runs.

## Related Issues

None.