### PR TITLE
docs: add CLAUDE.md and refresh AGENTS.md for cross-alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,9 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-03-05T15:00:40Z
-**Commit:** 1895191
+**Generated:** 2026-04-26T08:48:32Z
+**Commit:** b800b90
 **Branch:** main
+**Companion file:** see [CLAUDE.md](CLAUDE.md) for Claude Code workflow tips, daily commands, and operational gotchas; this file owns the structure tables, conventions, and reference data.
 
 ## OVERVIEW
 
@@ -12,77 +13,111 @@ Docker containerization for Futu OpenD — a trading API gateway for Futu Securi
 
 ```text
 .
-├── Dockerfile              # Multi-stage build (ubuntu/centos targets)
-├── docker-compose.yaml     # Local dev compose
+├── Dockerfile              # Multi-stage build (final-ubuntu-target / final-centos-target)
+├── docker-compose.yaml     # Local dev compose (host net + futu-opend-data volume)
 ├── FutuOpenD.xml           # Config template (sed-replaced at runtime)
 ├── opend_version.json      # Version tracking (auto-updated by CI)
+├── package.json            # npm scripts: test:unit, test:e2e (jsdom dep)
+├── .env / .env.e2e         # Compose env (.env.e2e is e2e-generated, mode 0600)
+├── docs/
+│   └── E2E.md              # End-to-end test harness deep-dive
 ├── script/
-│   ├── start.sh            # Entrypoint — replaces XML placeholders
-│   ├── download_futu_opend.sh  # Downloads FutuOpenD (3 retries, exponential backoff)
+│   ├── start.sh            # Entrypoint — replaces XML placeholders, MD5s password
+│   ├── download_futu_opend.sh  # Downloads FutuOpenD tarball (3 attempts total, fixed 2 s delay between retries)
 │   ├── check_version.js    # Version scraper with retry, timeout, validation
-│   └── check_version.test.js  # Unit tests (node:test)
-└── .github/workflows/      # CI: publish, lint, version-check, pr-agent
+│   ├── check_version.test.js   # Unit tests (node:test, CJS)
+│   ├── e2e.test.mjs        # E2E suite (node:test, ESM, 6 assertions, live OpenD)
+│   └── lib/
+│       ├── docker.mjs      # compose / inspect / telnet helpers (ESM)
+│       └── _pending/       # Parked: futu-api SDK round-trip experiment (not active)
+└── .github/workflows/      # CI: publish, lint, version-check, auto-merge
 ```
 
 ## WHERE TO LOOK
 
-| Task                   | Location                                  | Notes                                      |
-| ---------------------- | ----------------------------------------- | ------------------------------------------ |
-| Add build arg          | `Dockerfile` L9, L20, L31, L38            | `FUTU_OPEND_VER`                           |
-| Modify startup         | `script/start.sh`                         | XML sed replacement happens here           |
-| Change CI triggers     | `.github/workflows/publish.yml`           | Matrix: BASE_IMG × VERSION                 |
-| Update config template | `FutuOpenD.xml`                           | Placeholders: `###VAR###`                  |
-| Version detection      | `script/check_version.js`                 | Scraper with retry, timeout, validation    |
-| Run tests              | `script/check_version.test.js`            | `node --test script/check_version.test.js` |
-| Download manually      | `script/download_futu_opend.sh --retry 3` | Retry with exponential backoff             |
+| Task                   | Location                                       | Notes                                                                                        |
+| ---------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Add build arg          | `Dockerfile` (FUTU_OPEND_VER ARG sites)        | Default `9.3.5308` is legacy; CI passes explicit value                                       |
+| Modify startup         | `script/start.sh`                              | XML sed replacement + MD5 hashing happens here                                               |
+| Change CI triggers     | `.github/workflows/publish.yml`                | Matrix: BASE_IMG × VERSION → GHCR                                                            |
+| Update config template | `FutuOpenD.xml`                                | Placeholders: `<api_port>`, `<login_pwd_md5>`, etc.                                          |
+| Version detection      | `script/check_version.js`                      | Scraper with retry, timeout, validation                                                      |
+| Run unit tests         | `script/check_version.test.js`                 | `npm run test:unit`                                                                          |
+| Run e2e suite          | `script/e2e.test.mjs`                          | `npm run test:e2e`; needs creds + `futu.pem` (see docs/E2E.md)                               |
+| Compose helpers (Node) | `script/lib/docker.mjs`                        | `composeUp`, `sendTelnetCommand`, `tailLogs`, `inspectHealth`                                |
+| Enable WebSocket       | `script/start.sh` (websocket section)          | Set `FUTU_OPEND_WEBSOCKET_PORT` (default disabled)                                           |
+| Persist login session  | `docker-compose.yaml` `futu-opend-data`        | Mounted at `/home/futu/.com.futunn.FutuOpenD`                                                |
+| Tweak compose env      | `.env` (auto-loaded) / `.env.e2e` (e2e)        | `FUTU_OPEND_VER` mirrors `opend_version.json` stable                                         |
+| Add npm script         | `package.json`                                 | Currently `test:unit`, `test:e2e`                                                            |
+| Download manually      | `bash script/download_futu_opend.sh <tarball>` | Single positional arg, e.g. `Futu_OpenD_10.2.6208_Ubuntu18.04.tar.gz`; retries 3× internally |
 
 ## CONVENTIONS
 
-- **Multi-stage Docker**: `final-ubuntu-target` / `final-centos-target` targets selected via `BASE_IMG` arg
-- **Non-root user**: All images run as `futu` user (created at build)
-- **Env var injection**: `FUTU_ACCOUNT_ID`, `FUTU_ACCOUNT_PWD`, `FUTU_OPEND_RSA_FILE_PATH`, `FUTU_OPEND_IP`, `FUTU_OPEND_PORT`
-- **Password hashing**: MD5 of password injected at runtime (L5 of start.sh)
-- **Version tracking**: `opend_version.json` updated by scheduled CI, triggers PR on change
+- **Multi-stage Docker**: `final-ubuntu-target` / `final-centos-target` selected by build `--target`; the unparameterised `final` alias defaults to Ubuntu. The `BASE_IMG` build arg is declared but no longer routes between targets — pass `--target` explicitly.
+- **Non-root user**: All images run as `futu` user (created at build).
+- **Env var injection**: `FUTU_ACCOUNT_ID`, `FUTU_ACCOUNT_PWD`, `FUTU_ACCOUNT_PWD_MD5` (priority over PWD), `FUTU_OPEND_RSA_FILE_PATH`, `FUTU_OPEND_IP`, `FUTU_OPEND_PORT` (11111), `FUTU_OPEND_TELNET_PORT` (22222), `FUTU_OPEND_WEBSOCKET_PORT` / `FUTU_OPEND_WEBSOCKET_IP` (optional).
+- **Password hashing**: MD5 of password computed at runtime by `start.sh` if `FUTU_ACCOUNT_PWD_MD5` is unset.
+- **Version tracking**: `opend_version.json` updated by scheduled CI; triggers PR on change.
+- **ESM boundary**: e2e code is `.mjs` (ESM); `check_version.test.js` stays CJS. Don't add `"type": "module"` to `package.json` until that migrates.
+- **Module conventions**: `script/lib/_pending/` holds parked experiments; never import from there in shipping code.
 
 ## ANTI-PATTERNS (THIS PROJECT)
 
-- **NEVER** run containers as root — `USER futu` enforced
-- **NEVER** hardcode credentials — use env vars or `.env` file
-- **NEVER** modify `FutuOpenD.xml` directly — it's a template, changes overwritten at runtime
-- **NEVER** skip RSA key — required for API encryption
+- **NEVER** run containers as root — `USER futu` enforced.
+- **NEVER** hardcode credentials — use env vars or `.env` file.
+- **NEVER** modify `FutuOpenD.xml` directly — it's a template; changes are overwritten by `sed` at runtime.
+- **NEVER** skip RSA key — required for API encryption.
+- **NEVER** swap `network_mode: host` for bridge — silent login failure (`>>>登录失败,网络异常` ~45 s in). See [CLAUDE.md](CLAUDE.md) gotchas.
+- **NEVER** ship `futu.pem` at mode `0600` to users — runtime UID mismatch breaks RSA. `docs/E2E.md` calls out 0644 explicitly (the README is silent on file mode).
+- **NEVER** assert healthcheck `= healthy` — known-broken (TCP probe targets loopback, OpenD binds hostname). Assert `≠ unhealthy`.
+- **NEVER** run `docker compose config` or `docker exec ... env` in shared sessions — leaks `FUTU_ACCOUNT_PWD`.
+- **NEVER** import `futu-api` from `script/lib/_pending/` — intentionally not in `package.json`.
 
 ## UNIQUE STYLES
 
-- **XML templating**: `sed -i` replaces `###PLACEHOLDER###` patterns in `FutuOpenD.xml` at container start
-- **Dual base images**: Ubuntu 16.04 and CentOS 7 supported via multi-stage Dockerfile
-- **Healthcheck**: `pgrep FutuOpenD` with 180s start period (slow startup expected)
-- **2FA flow**: User must `docker attach` and run `input_phone_verify_code -code=XXX`
+- **XML templating**: `sed -i` replaces placeholder patterns in `FutuOpenD.xml` at container start.
+- **Dual base images**: Ubuntu 18.04 (bionic, runtime) / CentOS 7 (runtime); build stages on Ubuntu 22.04 / CentOS 7 — bionic apt is bypassed for build reliability.
+- **Healthcheck split**: The Dockerfile-shipped healthcheck is `pgrep FutuOpenD` (works). The compose override is a TCP probe on `127.0.0.1:11111`, which is misconfigured (loopback vs. hostname bind) and stays in `starting` — see [CLAUDE.md](CLAUDE.md) gotchas.
+- **2FA flow**: SMS code delivery — telnet to port `22222` (preferred), `docker attach` interactive (`input_phone_verify_code -code=XXXXXX`), or e2e file-drop at `/tmp/futu-sms-code` for non-TTY runs.
+- **Login session persistence**: Named volume `futu-opend-data` at `/home/futu/.com.futunn.FutuOpenD`; the Dockerfile pre-creates the path with `futu:futu` ownership for first-mount inheritance.
 
 ## COMMANDS
 
-```bash
-# Build locally (Ubuntu)
-docker build -t futu-opend-docker --build-arg FUTU_OPEND_VER=9.3.5308 --build-arg BASE_IMG=ubuntu .
+> Day-to-day commands (build, compose, attach, test, version scrape, SMS delivery) live in [CLAUDE.md](CLAUDE.md). Update both files together when adding a workflow command.
 
-# Build locally (CentOS)
-docker build -t futu-opend-docker --build-arg FUTU_OPEND_VER=9.3.5308 --build-arg BASE_IMG=centos .
+## VERSIONS & PORTS
 
-# Run with compose (requires .env)
-docker compose up -d
+| Fact                        | Value                                  | Source of truth                                |
+| --------------------------- | -------------------------------------- | ---------------------------------------------- |
+| Stable OpenD                | 10.4.6408                              | `opend_version.json`                           |
+| Beta OpenD                  | null                                   | `opend_version.json`                           |
+| Build-arg default           | 9.3.5308                               | `Dockerfile` (legacy default; CI passes value) |
+| `.env` default              | 10.2.6208                              | `.env` (mirrors stable on bumps)               |
+| Runtime base (Ubuntu)       | `ubuntu:18.04` (bionic, binary compat) | `Dockerfile`                                   |
+| Build base (Ubuntu)         | `ubuntu:22.04` (jammy, apt works)      | `Dockerfile`                                   |
+| Runtime/build base (CentOS) | `centos:centos7`                       | `Dockerfile`                                   |
+| API port                    | 11111                                  | env `FUTU_OPEND_PORT`                          |
+| Telnet/2FA port             | 22222                                  | env `FUTU_OPEND_TELNET_PORT`                   |
+| WebSocket port (optional)   | 33333 (e2e default; opt-in)            | env `FUTU_OPEND_WEBSOCKET_PORT`                |
 
-# Attach for 2FA
-docker attach futu-opend
-input_phone_verify_code -code=XXXXXX
+## E2E TEST HARNESS
 
-# Check for new versions
-node script/check_version.js
-```
+Local-only `node:test` suite that drives a real login. CI keeps its existing exit-code gate.
+
+- **Entrypoint**: `script/e2e.test.mjs` — 6 assertions (health ≠ unhealthy, `pgrep`, TCP `11111`, no login-failure markers, WebSocket HTTP `101` on `33333`, post-test health).
+- **Helpers**: `script/lib/docker.mjs` — `composeUp`, `composeDown`, `sendTelnetCommand`, `tailLogs`, `inspectHealth`, `waitForHealthy`.
+- **Inputs**: `FUTU_ACCOUNT_ID` / `FUTU_ACCOUNT_PWD` env vars, or pre-populated `.env.e2e` (mode `0600`).
+- **2FA**: telnet to `22222` with CRLF; non-TTY drop at `/tmp/futu-sms-code` polled every 1 s (5 min budget).
+- **Ready signal**: log marker `>>>WebSocket监听地址` (post-login) plus TCP probes on `11111` and `33333`.
+- **Run**: `npm run test:e2e` (10-minute overall budget).
+- **Full prerequisites & architecture**: see [docs/E2E.md](docs/E2E.md).
 
 ## NOTES
 
-- **RSA key required**: Generate with `openssl genrsa -out futu.pem 1024`, mount to container
-- **Slow startup**: FutuOpenD takes 2-3 minutes to initialize; healthcheck has 180s grace period
-- **2FA required**: First run needs SMS code input via attached terminal
-- **Tests**: `node --test script/check_version.test.js` (uses built-in node:test)
-- **Download**: `script/download_futu_opend.sh --retry 3` (retry with exponential backoff)
-- **Disclaimer**: Not affiliated with Futu Securities
+- **RSA key required**: Generate with `openssl genrsa -out futu.pem 1024`, then `chmod 0644 futu.pem` (the implicit `0600` from `genrsa` breaks the in-container `futu` UID — see [CLAUDE.md](CLAUDE.md) gotchas).
+- **Slow startup**: FutuOpenD takes 2–3 minutes to initialize; the Dockerfile healthcheck has a 180 s grace period. The compose healthcheck is misconfigured — see UNIQUE STYLES.
+- **2FA required**: First run needs SMS code input. See `## E2E TEST HARNESS` and CLAUDE.md gotchas for the three delivery routes.
+- **Tests**: `npm run test:unit` (`node --test script/check_version.test.js`) and `npm run test:e2e` (`node --test --test-timeout=600000 script/e2e.test.mjs`).
+- **Download**: `bash script/download_futu_opend.sh <tarball-name>` (single positional argument; the script attempts up to 3 times with a fixed 2 s delay between retries).
+- **Login session persistence**: `futu-opend-data` named volume avoids SMS re-prompt across container recreate. Wipe with `docker compose down -v`. See [README.md](README.md) "Login session persistence" for the full story.
+- **Disclaimer**: Not affiliated with Futu Securities.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project at a glance
+
+Docker container for **FutuOpenD** — Futu Securities' trading API gateway. Multi-stage build with Ubuntu 18.04 / CentOS 7 runtime images, published to GHCR. For the project knowledge base (file map, conventions, anti-patterns) see [AGENTS.md](AGENTS.md); for the e2e harness deep-dive see [docs/E2E.md](docs/E2E.md).
+
+## Common commands
+
+```bash
+# Build locally (Ubuntu runtime — default)
+docker build -t futu-opend-docker \
+  --build-arg FUTU_OPEND_VER=10.2.6208 \
+  --target final-ubuntu-target .
+
+# Build locally (CentOS runtime)
+docker build -t futu-opend-docker \
+  --build-arg FUTU_OPEND_VER=10.2.6208 \
+  --target final-centos-target .
+
+# Run with compose (uses .env + ./futu.pem)
+docker compose up -d
+docker compose logs -f futu-opend
+docker compose down            # preserves the futu-opend-data volume
+docker compose down -v         # wipes the persisted login session
+
+# Single unit test
+node --test script/check_version.test.js
+npm run test:unit              # alias for the line above
+
+# Full e2e suite (real login, ~10 min budget). See docs/E2E.md for prereqs.
+npm run test:e2e
+
+# Scrape Futu's download page for new versions
+node script/check_version.js
+
+# Manually fetch the FutuOpenD tarball
+bash script/download_futu_opend.sh Futu_OpenD_10.2.6208_Ubuntu18.04.tar.gz
+
+# Deliver SMS 2FA via telnet (preferred for automation; `docker attach` is the
+# interactive alternative — see README Method 1)
+echo "input_phone_verify_code -code=XXXXXX" | telnet localhost 22222
+
+# Deliver SMS 2FA to the e2e harness when running non-TTY (CI / agent)
+echo 123456 > /tmp/futu-sms-code
+```
+
+## Architecture: read these files in order
+
+1. **`Dockerfile`** — multi-stage. Build stages on `ubuntu:22.04` / `centos:centos7`; runtime stages on `ubuntu:18.04` (bionic, binary compat) / `centos:centos7`. Targets `final-ubuntu-target` (default for compose and the `final` alias) and `final-centos-target`. Each runtime stage creates the non-root `futu` user and pre-creates `/home/futu/.com.futunn.FutuOpenD` so a named volume mount inherits `futu:futu` ownership.
+2. **`script/start.sh`** — runtime brain. `sed`-templates `FutuOpenD.xml` (placeholders like `<api_port>`, `<rsa_private_key>`), MD5-hashes `FUTU_ACCOUNT_PWD` if `FUTU_ACCOUNT_PWD_MD5` is unset, conditionally enables WebSocket when `FUTU_OPEND_WEBSOCKET_PORT` is set, then launches `/bin/FutuOpenD -cfg_file=/tmp/FutuOpenD.xml` as a child process (no `exec` builtin — bash stays as PID 1, which means signals to the container are not forwarded to FutuOpenD).
+3. **`docker-compose.yaml`** — `network_mode: host` (mandatory; bridge silently fails) plus the named volume `futu-opend-data` for login session persistence. Healthcheck is a TCP probe on `127.0.0.1:11111` (see gotcha below).
+4. **`script/e2e.test.mjs` + `script/lib/docker.mjs`** — local-only `node:test` e2e suite. 6 assertions, telnet-based 2FA delivery, file-drop fallback for non-TTY runs. Full architecture in [docs/E2E.md](docs/E2E.md).
+5. **`.github/workflows/publish.yml`** — matrix CI (`BASE_IMG` × `FUTU_OPEND_VER`) → GHCR. A `dorny/paths-filter` step is meant to skip the build when changes are limited to `README.md`, `LICENSE`, `.github/workflows/check-ver-update.yml`, or `.github/workflows/lint.yml` — but the third entry has a typo: the actual file on disk is `check-ver-upadte.yml`, so version-check edits still trigger a publish in practice.
+
+## Critical gotchas
+
+- **Host network is mandatory.** Bridge networking produces `>>>登录失败,网络异常` ~45 s after login attempt with healthy creds. Both `network_mode: host` and `build.network: host` are set in `docker-compose.yaml`; do not flip them without a verified replacement.
+- **`futu.pem` must be mode `0644`, not `0600`.** The container runs as the `futu` UID, distinct from the host user that owns the bind-mounted file. `0600` silently disables RSA (`>>>API启用RSA: 否`) and Futu rejects login.
+- **Named volume `futu-opend-data`** at `/home/futu/.com.futunn.FutuOpenD` persists the login session (device-whitelist token, captcha PNG). The current Dockerfile pre-creates that path with `futu:futu` ownership so a fresh mount inherits the right uid; pre-PR-65 images didn't, so a volume created against an older image will keep its root-owned mount point and fail with EACCES on first write. Fix with `docker compose down -v` (wipes the volume — costs the cached login session, requires a fresh SMS code on next start). `docker compose pull` does **not** help: this compose file builds locally (no `image:` directive) and the volume's contents are preserved across image bumps.
+- **Compose healthcheck stays in `starting` forever.** It runs `</dev/tcp/127.0.0.1/11111`, but FutuOpenD binds the hostname-resolved interface (set by `FUTU_OPEND_IP=0.0.0.0`), not loopback. Tests should assert `state.Health.Status != "unhealthy"`, never `== "healthy"`. The Dockerfile-shipped healthcheck is `pgrep FutuOpenD` — use that as ground truth.
+- **2FA / SMS delivery** has three routes: (1) telnet to port `22222` with CRLF — preferred for automation; (2) `docker attach futu-opend` for interactive use; (3) e2e harness file-drop at `/tmp/futu-sms-code` for non-TTY runs.
+- **Two password env vars; MD5 wins.** `FUTU_ACCOUNT_PWD_MD5` takes priority over `FUTU_ACCOUNT_PWD`; if only the plaintext is set, `start.sh` MD5-hashes it at runtime.
+- **Avoid `docker compose config` and `docker exec <container> env`** — both leak `FUTU_ACCOUNT_PWD` in plaintext.
+- **Futu rate-limits rapid login retries.** Wait 30+ minutes between aggressive debug cycles; rate-limit messages look identical to network errors.
+
+## Pointers
+
+- Project knowledge base (file map, conventions, anti-patterns, version/port reference) → [AGENTS.md](AGENTS.md)
+- E2E harness deep-dive (architecture, prerequisites, 2FA handling, troubleshooting) → [docs/E2E.md](docs/E2E.md)
+- User-facing usage (image tags, prerequisites, login flow) → [README.md](README.md)


### PR DESCRIPTION
## Summary

Add a Claude Code entry point at `CLAUDE.md` and refresh the project knowledge base in `AGENTS.md` so the two files cross-align. Each fact has exactly one home: `CLAUDE.md` owns daily commands + critical gotchas, `AGENTS.md` owns the file-map / conventions / version+port reference, and both defer to `docs/E2E.md` for the e2e deep-dive.

## Changes

- **New:** `CLAUDE.md` — preamble, common commands, 5-step architecture reading order, 8 critical operational gotchas (host net, RSA mode, named-volume ownership, healthcheck quirk, SMS routes, MD5 priority, env-leak pitfalls, Futu rate-limit), pointers to companion docs.
- **Updated:** `AGENTS.md` — header metadata refreshed (commit `b800b90`, 2026-04-26); new sections `## VERSIONS & PORTS` and `## E2E TEST HARNESS`; `WHERE TO LOOK` table extended with rows for e2e suite, compose helpers, named volume, npm scripts; corrected download script CLI signature (positional arg, fixed 2 s delay); noted `publish.yml` path-filter has a typo (`check-ver-update.yml`) that doesn't match the actual file (`check-ver-upadte.yml`).
- **No code changes.** Markdown only.

## Files Changed

| Path | Change |
|---|---|
| `CLAUDE.md` | Added |
| `AGENTS.md` | Modified |

## Testing

- \`npm run test:unit\` → 16/16 pass.
- All file paths referenced in both docs verified to exist on disk.
- All cross-document attributions verified (README \"Method 1\", README \"Login session persistence\", \`docs/E2E.md\` 0644 mention).
- Doc claims spot-checked against \`Dockerfile\`, \`docker-compose.yaml\`, \`script/start.sh\`, \`script/e2e.test.mjs\`, \`script/lib/docker.mjs\`, \`.github/workflows/publish.yml\`, and the \`check-ver-upadte.yml\` schedule/PR-creation logic.
- Four self-review rounds (HIGH×2, MEDIUM×4, LOW×2 — all fixed).

## Related Issues

None.