### PR TITLE
ci: drop redundant ref pin from publish workflow checkouts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,6 @@ jobs:
       should-build: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.sha }}
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -37,8 +35,6 @@ jobs:
       stable_version: ${{ steps.stable_version.outputs.result }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.sha }}
       - uses: actions/github-script@v7
         id: beta_version
         with:
@@ -79,8 +75,6 @@ jobs:
       STABLE_VERSION: ${{ needs.extract-version.outputs.stable_version }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.sha }}
 
       - name: Docker login
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary

`actions/checkout@v4` already defaults to the triggering event's ref/sha. The publish workflow runs only on `push: branches: [main]`, so all three checkouts already share one `GITHUB_SHA` — `ref: ${{ github.sha }}` is redundant. This PR removes the three pin lines, leaving the workflow's behavior identical.

## Changes

- **`.github/workflows/publish.yml`** (`check-paths`, `extract-version`, `build` jobs): drop `with: { ref: ${{ github.sha }} }` from each `actions/checkout@v4` step.

## Files Changed

| File | Change |
|---|---|
| `.github/workflows/publish.yml` | Modified (-6 lines) |

## Testing

- `pre-commit run --all-files` → all hooks pass (yamllint, prettier, etc.)
- Verified with `act` (real run, stripped harness mirroring matrix and tag-rendering steps) that the full set of pushed tags across the ubuntu/centos matrix is unchanged:
  ```
  ghcr.io/manhinhang/futu-opend-docker:ubuntu-10.4.6408
  ghcr.io/manhinhang/futu-opend-docker:ubuntu-stable
  ghcr.io/manhinhang/futu-opend-docker:centos-10.4.6408
  ghcr.io/manhinhang/futu-opend-docker:centos-stable
  ```
  `grep -iE "sha|hash"` over act's full output: zero matches. No commit-SHA-suffixed image is published.
- End-to-end CI verification will run automatically after merge — the workflow's `dorny/paths-filter` skip rule does not list `.github/workflows/publish.yml`, so the matrix build will execute and confirm both pulls (`ubuntu-stable`, `ubuntu-10.4.6408`) still resolve.

## Related Issues

None.

## Notes

- Plan: `~/.claude/plans/don-t-need-publish-sha-lovely-steele.md` (local).
- The phrasing "publish sha hash container image" was clarified upfront — the publish workflow never emitted a SHA-tagged image; the request targeted the redundant `ref:` pins on `actions/checkout`.