### PR TITLE
feat: support arm64 hosts via amd64 emulation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,14 +60,16 @@ jobs:
             }
             return {
                 "BASE_IMG": ["ubuntu", "centos"],
-                "FUTU_OPEND_VER": versions
+                "FUTU_OPEND_VER": versions,
+                "RUNNER": ["ubuntu-latest", "ubuntu-24.04-arm"]
             };
 
   build:
     strategy:
+      fail-fast: false
       matrix: ${{ fromJSON(needs.extract-version.outputs.matrix) }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    runs-on: ${{ matrix.RUNNER }}
+    timeout-minutes: 30
     needs: [extract-version]
     env:
       IMAGE_NAME: ghcr.io/${{ github.repository }}
@@ -75,6 +77,15 @@ jobs:
       STABLE_VERSION: ${{ needs.extract-version.outputs.stable_version }}
     steps:
       - uses: actions/checkout@v4
+
+      # FutuOpenD ships an x86_64-only binary, so the image is always
+      # linux/amd64. On arm64 runners QEMU lets that image build and run
+      # under emulation, validating the healthcheck on both architectures.
+      - name: Set up QEMU
+        if: runner.arch == 'ARM64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64
 
       - name: Docker login
         uses: docker/login-action@v3
@@ -100,6 +111,7 @@ jobs:
         with:
           push: false
           load: true
+          platforms: linux/amd64
           target: final-${{ matrix.BASE_IMG }}-target
           build-args: |
             FUTU_OPEND_VER=${{ matrix.FUTU_OPEND_VER }}
@@ -110,9 +122,10 @@ jobs:
 
       - name: Validate Docker image
         run: |
-          echo "=== Starting container for validation ==="
+          echo "=== Starting container for validation (runner arch: ${{ runner.arch }}) ==="
           docker run -d \
             --name futu-opend-test \
+            --platform linux/amd64 \
             -e FUTU_ACCOUNT_ID="" \
             -e FUTU_ACCOUNT_PWD_MD5="" \
             ${{ env.IMAGE_NAME }}:${{ matrix.BASE_IMG }}-${{ matrix.FUTU_OPEND_VER }}
@@ -130,9 +143,10 @@ jobs:
           # Give process time to start
           sleep 5
 
-          # Check if process started (validates binary works)
+          # Check if process started (validates binary works). Allow extra
+          # time on arm64 runners where the amd64 binary runs under QEMU.
           echo "Checking if FutuOpenD process started..."
-          if timeout 10s sh -c 'until docker exec futu-opend-test pgrep FutuOpenD 2>/dev/null; do sleep 1; done'; then
+          if timeout 30s sh -c 'until docker exec futu-opend-test pgrep FutuOpenD 2>/dev/null; do sleep 1; done'; then
             echo "✓ FutuOpenD process started successfully"
             PROCESS_STARTED=true
           else
@@ -174,7 +188,10 @@ jobs:
             exit 1
           fi
 
+      # Push only from the x86 runner — the image is identical on both, and
+      # the arm64 job exists solely to validate the healthcheck under emulation.
       - name: Push Docker image
+        if: runner.arch == 'X64'
         run: |
           docker push ${{ env.IMAGE_NAME }}:${{ matrix.BASE_IMG }}-${{ matrix.FUTU_OPEND_VER }}
           docker push ${{ env.IMAGE_NAME }}:${{ matrix.BASE_IMG }}-${{ steps.tag_suffix.outputs.result }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ echo 123456 > /tmp/futu-sms-code
 - **`FUTU_ACCOUNT_PWD` is deprecated; use `FUTU_ACCOUNT_PWD_MD5`.** `start.sh` still accepts plaintext as a legacy fallback (it MD5-hashes at runtime) but emits a stderr `WARNING: FUTU_ACCOUNT_PWD is deprecated…` when only the plaintext is set. `FUTU_ACCOUNT_PWD_MD5` takes priority when both are set.
 - **Avoid `docker compose config` and `docker exec <container> env`** — both leak `FUTU_ACCOUNT_PWD` in plaintext (and `FUTU_ACCOUNT_PWD_MD5` if set, though the hash is less catastrophic than the original).
 - **Futu rate-limits rapid login retries.** Wait 30+ minutes between aggressive debug cycles; rate-limit messages look identical to network errors.
+- **No native arm64 image.** FutuOpenD ships as an x86_64-only binary; the image is always `linux/amd64`. On arm64 hosts it runs via QEMU/Rosetta emulation — `docker-compose.yaml` pins `platform: linux/amd64`, and `docker run` / `docker build` users pass `--platform linux/amd64`. Do not add an arm64 build target until Futu publishes an aarch64 tarball.
 
 ## Pointers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ echo 123456 > /tmp/futu-sms-code
 2. **`script/start.sh`** — runtime brain. `sed`-templates `FutuOpenD.xml` (placeholders like `<api_port>`, `<rsa_private_key>`), MD5-hashes `FUTU_ACCOUNT_PWD` if `FUTU_ACCOUNT_PWD_MD5` is unset (and emits a stderr deprecation warning when only the plaintext is set), conditionally enables WebSocket when `FUTU_OPEND_WEBSOCKET_PORT` is set, then launches `/bin/FutuOpenD -cfg_file=/tmp/FutuOpenD.xml` as a child process (no `exec` builtin — bash stays as PID 1, which means signals to the container are not forwarded to FutuOpenD).
 3. **`docker-compose.yaml`** — `network_mode: host` (mandatory; bridge silently fails) plus the named volume `futu-opend-data` for login session persistence. Healthcheck is a TCP probe on `127.0.0.1:11111` (see gotcha below).
 4. **`script/e2e.test.mjs` + `script/lib/docker.mjs`** — local-only `node:test` e2e suite. 6 assertions, telnet-based 2FA delivery, file-drop fallback for non-TTY runs. Full architecture in [docs/E2E.md](docs/E2E.md).
-5. **`.github/workflows/publish.yml`** — matrix CI (`BASE_IMG` × `FUTU_OPEND_VER`) → GHCR. A `dorny/paths-filter` step skips the build when changes are limited to `README.md`, `LICENSE`, `.github/workflows/check-ver-update.yml`, or `.github/workflows/lint.yml`.
+5. **`.github/workflows/publish.yml`** — matrix CI (`BASE_IMG` × `FUTU_OPEND_VER` × `RUNNER`) → GHCR. The `RUNNER` axis (`ubuntu-latest`, `ubuntu-24.04-arm`) validates the healthcheck on both x86 and arm64 (the arm64 job runs the amd64 image under QEMU); only the x86 runner pushes. A `dorny/paths-filter` step skips the build when changes are limited to `README.md`, `LICENSE`, `.github/workflows/check-ver-update.yml`, or `.github/workflows/lint.yml`.
 
 ## Critical gotchas
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ lightweight futu opend docker
 docker pull ghcr.io/manhinhang/futu-opend-docker:ubuntu-stable
 ```
 
+> **arm64 / Apple Silicon hosts**: FutuOpenD is an x86_64-only binary —
+> Futu publishes no native ARM64 build. The image still runs on arm64
+> hosts (Apple Silicon Macs, ARM servers) through Docker's amd64
+> emulation (QEMU/Rosetta). Add `--platform linux/amd64` to `docker pull`
+> / `docker run`; the compose file already pins `platform: linux/amd64`.
+
 ## container tags pattern
 
 | Base Image | Tags                   |
@@ -44,6 +50,7 @@ docker pull ghcr.io/manhinhang/futu-opend-docker:ubuntu-stable
 # Compute the password MD5 so plaintext never lands in your shell history.
 FUTU_ACCOUNT_PWD_MD5=$(echo -n '<your_password>' | md5sum | awk '{print $1}')
 
+# On an arm64 host, add: --platform linux/amd64
 docker run -it --name futu-opend-docker \
 -e FUTU_ACCOUNT_ID=<your_account_id> \
 -e FUTU_ACCOUNT_PWD_MD5="$FUTU_ACCOUNT_PWD_MD5" \
@@ -287,6 +294,10 @@ echo "input_pic_verify_code -code=<CAPTCHA_CODE>" | telnet localhost 22222
 ## Build locally
 
 > **Note**: Ubuntu builds require version 9.4.x or later with Ubuntu 18.04 base image. Ubuntu 16.04 builds are no longer provided by Futu.
+>
+> **arm64 hosts**: pass `--platform linux/amd64` to `docker build` — the
+> FutuOpenD binary is x86_64-only, so the image is always amd64 and runs
+> under emulation on ARM.
 
 - Use ubuntu as base image
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,10 @@ services:
         FUTU_OPEND_VER: ${FUTU_OPEND_VER}
         BASE_IMG: ubuntu
     container_name: futu-opend
+    # FutuOpenD is an x86_64-only binary — Futu ships no aarch64 build. On
+    # arm64 hosts (Apple Silicon, ARM servers) this pins the image to amd64
+    # so it runs under QEMU/Rosetta emulation. On amd64 hosts it's a no-op.
+    platform: linux/amd64
     stdin_open: true
     tty: true
     # Host network for OpenD's outbound to Futu — the docker bridge silently


### PR DESCRIPTION
FutuOpenD ships only an x86_64 Linux binary, so the image is always
linux/amd64. Pin platform: linux/amd64 in compose and document the
--platform flag for docker run/build so the image runs under QEMU on
arm64 hosts (Apple Silicon, ARM servers).

https://claude.ai/code/session_012nr9LKrJMDYPzyHDbsADqA